### PR TITLE
DLPX-78618 Cherry-pick makedumpfile fix for 5.11 kernels

### DIFF
--- a/makedumpfile.c
+++ b/makedumpfile.c
@@ -1169,7 +1169,10 @@ check_release(void)
 	if (SYMBOL(system_utsname) != NOT_FOUND_SYMBOL) {
 		utsname = SYMBOL(system_utsname);
 	} else if (SYMBOL(init_uts_ns) != NOT_FOUND_SYMBOL) {
-		utsname = SYMBOL(init_uts_ns) + sizeof(int);
+		if (OFFSET(uts_namespace.name) != NOT_FOUND_STRUCTURE)
+			utsname = SYMBOL(init_uts_ns) + OFFSET(uts_namespace.name);
+		else
+			utsname = SYMBOL(init_uts_ns) + sizeof(int);
 	} else {
 		ERRMSG("Can't get the symbol of system_utsname.\n");
 		return FALSE;
@@ -2050,6 +2053,11 @@ get_structure_info(void)
 	SIZE_INIT(cpu_spec, "cpu_spec");
 	OFFSET_INIT(cpu_spec.mmu_features, "cpu_spec", "mmu_features");
 
+	/*
+	 * Get offsets of the uts_namespace's members.
+	 */
+	OFFSET_INIT(uts_namespace.name, "uts_namespace", "name");
+
 	return TRUE;
 }
 
@@ -2119,7 +2127,10 @@ get_str_osrelease_from_vmlinux(void)
 	if (SYMBOL(system_utsname) != NOT_FOUND_SYMBOL) {
 		utsname = SYMBOL(system_utsname);
 	} else if (SYMBOL(init_uts_ns) != NOT_FOUND_SYMBOL) {
-		utsname = SYMBOL(init_uts_ns) + sizeof(int);
+		if (OFFSET(uts_namespace.name) != NOT_FOUND_STRUCTURE)
+			utsname = SYMBOL(init_uts_ns) + OFFSET(uts_namespace.name);
+		else
+			utsname = SYMBOL(init_uts_ns) + sizeof(int);
 	} else {
 		ERRMSG("Can't get the symbol of system_utsname.\n");
 		return FALSE;
@@ -2354,6 +2365,7 @@ write_vmcoreinfo_data(void)
 	WRITE_MEMBER_OFFSET("vmemmap_backing.list", vmemmap_backing.list);
 	WRITE_MEMBER_OFFSET("mmu_psize_def.shift", mmu_psize_def.shift);
 	WRITE_MEMBER_OFFSET("cpu_spec.mmu_features", cpu_spec.mmu_features);
+	WRITE_MEMBER_OFFSET("uts_namespace.name", uts_namespace.name);
 
 	if (SYMBOL(node_data) != NOT_FOUND_SYMBOL)
 		WRITE_ARRAY_LENGTH("node_data", node_data);
@@ -2754,6 +2766,7 @@ read_vmcoreinfo(void)
 	READ_MEMBER_OFFSET("vmemmap_backing.list", vmemmap_backing.list);
 	READ_MEMBER_OFFSET("mmu_psize_def.shift", mmu_psize_def.shift);
 	READ_MEMBER_OFFSET("cpu_spec.mmu_features", cpu_spec.mmu_features);
+	READ_MEMBER_OFFSET("uts_namespace.name", uts_namespace.name);
 
 	READ_STRUCTURE_SIZE("printk_log", printk_log);
 	READ_STRUCTURE_SIZE("printk_ringbuffer", printk_ringbuffer);

--- a/makedumpfile.h
+++ b/makedumpfile.h
@@ -1728,6 +1728,8 @@ struct size_table {
 	long	cpu_spec;
 
 	long	pageflags;
+
+	long	uts_namespace;
 };
 
 struct offset_table {
@@ -1935,6 +1937,10 @@ struct offset_table {
 	struct cpu_spec_s {
 		long	mmu_features;
 	} cpu_spec;
+
+	struct uts_namespace_s {
+		long	name;
+	} uts_namespace;
 };
 
 /*


### PR DESCRIPTION
Add the following commit to fix recent crash-dump corruptions on 5.11 kernels:

```
[PATCH] make use of 'uts_namespace.name' offset in VMCOREINFO

* Required for kernel 5.11

The offset of the field 'init_uts_ns.name' has changed since
kernel commit 9a56493f6942 ("uts: Use generic ns_common::count").
Make use of the offset 'uts_namespace.name' if available in
VMCOREINFO.

Signed-off-by: Alexander Egorenkov <egorenar@linux.ibm.com>
```

# Testing

Started ab-pre-push here: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6677/

Using the VM generated from the above run I generated a crash dump on AWS and made sure that we can read it with our utilities.
```
delphix@ip-10-110-202-215:~$ uname -a
Linux ip-10-110-202-215 5.11.0-1021-dx2021111105-4e77a59b5-aws #22~20.04.2 SMP Thu Nov 11 05:32:46 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
delphix@ip-10-110-202-215:~$ sudo su
root@ip-10-110-202-215:/export/home/delphix# echo c > /proc/sysrq-triggerclient_loop: send disconnect: Broken pipe
sdimitropoulos@bullshark:~$ ssh delphix@sdimitro-makedump.dlpxdc.co
delphix@ip-10-110-202-215:~$ ls /var/crash/
202112032013  kdump_lock  kexec_cmd
delphix@ip-10-110-202-215:~$ cd /var/crash/202112032013/
delphix@ip-10-110-202-215:/var/crash/202112032013$ sudo sdb /usr/lib/debug/boot/vmlinux-5.11.0-1021-dx2021111105-4e77a59b5-aws dump.202112032013
sdb> spa
ADDR               NAME
------------------------------------------------------------
0xffff90600d8d0000 rpool
sdb>
delphix@ip-10-110-202-215:/var/crash/202112032013$ sudo crash.sh /usr/lib/debug/boot/vmlinux-5.11.0-1021-dx2021111105-4e77a59b5-aws dump.202112032013
Slick Debugger (sdb) initializing...
...cropped..
sdb> spa
ADDR           NAME
------------------------------------------------------------
0xffff90600d8d0000 rpool
sdb> quit
```