### PR TITLE
DLPX-84173 makedumpfile progress output with new-line chars

### DIFF
--- a/makedumpfile.c
+++ b/makedumpfile.c
@@ -4414,6 +4414,14 @@ out:
 	if (is_xen_memory() && !get_dom0_mapnr())
 		return FALSE;
 
+	/*
+	 * If kdump-tools called us, set flag_ignore_r_char since stderr
+	 * will be sent to a line buffering console and we want the '\r'
+	 * to be replace by a '\n' in PROGRESS_MSG() output.
+	 */
+	if (getenv("KDUMP_KERNEL") != NULL)
+		flag_ignore_r_char = 1;
+
 	if (debug_info) {
 		if (info->flag_sadump)
 			(void) sadump_virt_phys_base();

--- a/print_info.c
+++ b/print_info.c
@@ -383,10 +383,11 @@ print_progress(const char *msg, unsigned long current, unsigned long end, struct
 	struct timespec delta;
 	unsigned long eta;
 	char eta_msg[16] = " ";
+	time_t frequency = flag_ignore_r_char ? 10 : 1;
 
 	if (current < end) {
 		tm = time(NULL);
-		if (tm - last_time < 1)
+		if (tm - last_time < frequency)
 			return;
 		last_time = tm;
 		progress = current * 1000 / end;
@@ -400,9 +401,8 @@ print_progress(const char *msg, unsigned long current, unsigned long end, struct
 		eta_to_human_short(eta, eta_msg);
 	}
 	if (flag_ignore_r_char) {
-		PROGRESS_MSG("%-" PROGRESS_MAXLEN "s: [%3u.%u %%] %c  %16s\n",
-			     msg, progress / 10, progress % 10,
-			     spinner[lapse % 4], eta_msg);
+		PROGRESS_MSG("%-" PROGRESS_MAXLEN "s: [%3u.%u %%]  %16s\n",
+			     msg, progress / 10, progress % 10, eta_msg);
 	} else {
 		PROGRESS_MSG("\r");
 		PROGRESS_MSG("%-" PROGRESS_MAXLEN "s: [%3u.%u %%] %c  %16s",


### PR DESCRIPTION
### Problem
The makedumpfile progress output uses a carriage return ('\r') and outputs
to stderr (which is not buffered).  When used with the console and the crash
kernel, this output is redirected into stdout which is line buffered.  This
results in no dump file progress updates to the console.
### Evaluation
The console buffering issue can be simulated using stdbuf, as in:
  $ stdbuf -eL makedumpfile -c -d 31 --message-level 23 dump.202212130941 testdump

No progress is observed until the summary output is reached.
### Solution
Use the existing flag, flag_ignore_r_char,  to suppress using '\r' chars.
Also, decrease the progress update frequency to 10 seconds (was 1 sec) and
omit outputting the spinner characters.
### Testing Done
Tested by generating a panic with lots of dirty memory and observed that the
progress output is seen in the console.

![console-progress](https://user-images.githubusercontent.com/12415697/210891972-c24bda58-77ac-4d5c-8bd2-8efc3ce6ad7e.png)

### Implementation
Checks if the environment variable, KDUMP_KERNEL, is set and if so it enables
the flag_ignore_r_char flag.
### Deployment Plan
This PR should land first followed by DLPX-83991 which requests progress output.
